### PR TITLE
Automatically restart from scratch if no checkpoint

### DIFF
--- a/lib/recovery.q
+++ b/lib/recovery.q
@@ -23,13 +23,9 @@ loadCheckpoint:{[]
     utxoLocation:` sv (checkpointDB;`utxoTable);
     checkpointLocation:` sv (checkpointDB;`checkpoint);
 
-    if[()~key checkpointLocation;
-      show "No checkpoint table found for recovery reboot...exiting";
-      exit 0
-    ];
-    if[()~key utxoLocation;
-      show "No utxo table found for recovery reboot...exiting";
-      exit 0
+    if[()~key checkpointLocation or ()~key utxoLocation;
+      show "No checkpoint table found for recovery reboot...restarting";
+      startIndex:0f
     ];
 
     lastUTXO:get utxoLocation;
@@ -41,8 +37,8 @@ loadCheckpoint:{[]
   if[instanceName~`refDBGenerator;
     refLocation:` sv (checkpointDB;`referenceTracker);
     if[()~key refLocation;
-      show "No referenceTracker table found for recovery reboot...exiting";
-      exit 0
+      show "No referenceTracker table found for recovery reboot...restarting";
+      startIndex:0f
     ];
    lastRef:get refLocation;
    @[`.;`referenceTracker;:;lastRef];


### PR DESCRIPTION
There is no point in exiting if a checkpoint doesn't exist. Why don't we just start from scratch if one doesn't exist? Will also get rid of startIndex:0f from config file and get rid of .utl.addopt in favour of loadCheckpoint[] at every start up.