### PR TITLE
remove startIndex

### DIFF
--- a/config/settings.q
+++ b/config/settings.q
@@ -1,4 +1,3 @@
-startIndex:0f
 writeFreq:500f
 chunkSize:1000f
 freeMemFreq:500f


### PR DESCRIPTION
startIndex:0f will load in recovery.q if checkpoint doesn't exist