### PR TITLE
Always load checkpoint

### DIFF
--- a/app/qExplorer.q
+++ b/app/qExplorer.q
@@ -31,9 +31,7 @@ instanceName:`qExplorer
 // If present, then being from last successful checkpoint
 // This involves loading the utxo file and setting the startIndex
 ///////////////////////////////////////////////////////////////////////
-.utl.addOpt["recover";1b;{loadCheckpoint[]}];
-.utl.parseArgs[];
-
+loadCheckpoint[];
 
 index:startIndex;
 processBlock:{[Hash]


### PR DESCRIPTION
No harm in always loading the checkpoint upon reboot. Easier than specifying --recovery in terms of using docker, as a docker container will always automatically restart, read the script, and keep going. If there is no checkpoint to begin with, startIndex:0f (as per recovery.q pull request).