### PR TITLE
update hdb.q to not run when writing to disk

### DIFF
--- a/app/hdb.q
+++ b/app/hdb.q
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////
 /// Provide the path & file, and port in the command
-/// line as such --path="/opt/q/databases/mainDatabase/" 
+/// line as such --path="/opt/q/" 
 /// --port="9000" --file="mainDB"
 /////////////////////////////////////////////////////////
 
@@ -12,10 +12,19 @@
 
 value"\\l ",hdbPath;
 value"\\p ",hdbPort;
-value"\\l ",hdbFile
+value"\\l ",hdbFile;
 
-value "\\t 30000"
+value "\\t 60000";
+
 .z.ts:{
-  value"\\l ",hdbPath;
-  show["Refreshed ",hdbFile]
+  $[`.[`writeFreq]~1f+(`.[`index] mod `.[`writeFreq]);
+    [
+      `.[`printMsg]["Not loading ",hdbFile," yet, currently writing to disk"];
+      :()
+    ];
+    [
+      `.[`printMsg]["Loading ",hdbFile];
+      value"\\l ",hdbPath;
+    ]
+  ];
  }

--- a/app/hdb.q
+++ b/app/hdb.q
@@ -10,7 +10,7 @@
 .utl.addOpt["file";"*";`hdbFile];
 .utl.parseArgs[];
 
-value"\\l ",hdbPath;
+value"\\l ",hdbPath; 
 value"\\p ",hdbPort;
 value"\\l ",hdbFile;
 
@@ -24,7 +24,7 @@ value "\\t 60000";
     ];
     [
       `.[`printMsg]["Loading ",hdbFile];
-      value"\\l ",hdbPath;
+      system"l .";
     ]
   ];
  }


### PR DESCRIPTION
Prevents hdb.q from loaded hdbFile when qExplorer is writing to disk. Currently, if it does get called when writing to disk, you get an error (OS reports: No such file or directory).