### PR TITLE
Prevent hdb.q from running during write

### DIFF
--- a/app/hdb.q
+++ b/app/hdb.q
@@ -22,8 +22,8 @@ value"\\t 30000"
       :()
     ];
     [
-      `.[`printMsg]["Loading ",hdbFile];
       system"l .";
+      `.[`printMsg]["Loaded ",hdbFile]
     ]
   ];
  }

--- a/app/hdb.q
+++ b/app/hdb.q
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////
 /// Provide the path & file, and port in the command
-/// line as such --path="/opt/q/databases/mainDatabase/" 
+/// line as such --path="/opt/q/" 
 /// --port="9000" --file="mainDB"
 /////////////////////////////////////////////////////////
 
@@ -14,8 +14,16 @@ value"\\l ",hdbPath;
 value"\\p ",hdbPort;
 value"\\l ",hdbFile
 
-value "\\t 30000"
+value"\\t 30000"
 .z.ts:{
-  value"\\l ",hdbPath;
-  show["Refreshed ",hdbFile]
+  $[`.[`writeFreq]~1f+(`.[`index] mod `.[`writeFreq]);
+    [
+      `.[`printMsg]["Not loading ",hdbFile," yet, currently writing to disk"];
+      :()
+    ];
+    [
+      `.[`printMsg]["Loading ",hdbFile];
+      system"l .";
+    ]
+  ];
  }


### PR DESCRIPTION
Prevents hdb.q from erroring-out during a write so that no error (OS reports: No such file or directory) in hdb.q is thrown.