### PR TITLE
do not error when qExplorer is writing (no connection to qExplorer needed)

### DIFF
--- a/app/hdb.q
+++ b/app/hdb.q
@@ -18,15 +18,10 @@ printMsg:{[str]
   -1(string[.z.p]," "),str
  };
 
-value "\\t 30000"
+value "\\t 30000";
+f:{@[system;"l .";show]};
+
 .z.ts:{
-  $[()~key hsym `$hdbPath;
-    [
-      printMsg["Path to ",hdbFile," unavailable, we are currently writing to disk, please wait..."];
-    ];
-    [
-      system"l .";
-      printMsg["Refreshed the following database: ",hdbFile]
-    ]
-  ];
- }
+  printMsg["Probing for a new partion, refreshing the following database: ",hdbFile];
+  f[]
+}

--- a/app/hdb.q
+++ b/app/hdb.q
@@ -14,8 +14,19 @@ value"\\l ",hdbPath;
 value"\\p ",hdbPort;
 value"\\l ",hdbFile
 
+printMsg:{[str]
+  -1(string[.z.p]," "),str
+ };
+
 value "\\t 30000"
 .z.ts:{
-  value"\\l ",hdbPath;
-  show["Refreshed ",hdbFile]
+  $[()~key hsym `$hdbPath,hdbFile;
+    [
+      printMsg["Path to ",hdbFile," unavailable, we are currently writing to disk, please wait..."];
+    ];
+    [
+      system"l .";
+      printMsg["Refreshed the following database: ",hdbFile]
+    ]
+  ];
  }

--- a/app/hdb.q
+++ b/app/hdb.q
@@ -20,7 +20,7 @@ printMsg:{[str]
 
 value "\\t 30000"
 .z.ts:{
-  $[()~key hsym `$hdbPath,hdbFile;
+  $[()~key hsym `$hdbPath;
     [
       printMsg["Path to ",hdbFile," unavailable, we are currently writing to disk, please wait..."];
     ];


### PR DESCRIPTION
An update to my last pull request. 

Problem: I keep getting "mainDB: Path of file cannot be found" when hdb.q is called while qExplorer is writing to disk.

Solution: This should prevent the hdb from reloading during the period of time in which qExplorer is writing, without needing to open a connection to qExplorer.