### PR TITLE
Update save.q

### DIFF
--- a/lib/save.q
+++ b/lib/save.q
@@ -29,7 +29,7 @@ saveTransactionOutputs:{[Block]
   outputs:select height,txid,outputValue,address,n,scriptPubKey from outputs;
   utxoData:select txuid:(txid,'string[n]),inputValue:outputValue,address from outputs;
   insert[`txOutputs;outputs];
-  insert[`addressLookup;select address,height,partition:heightToPartition[index;chunkSize],tag:`$-3#'address,bitmex:{?[x like "3BMEX";1b;0b]}each 5#'address from outputs where not address like ""];
+  insert[`addressLookup;select address,height,partition:heightToPartition[index;chunkSize],tag:`$-3#'address,bitmex:?[(outputs`address) like "3BMEX";1b;0b] from outputs where not address like ""];
   upsert[`utxo;utxoData];
   update utxoIndex:i from `utxo;
   -1(string .z.p)," UTXO Count: ",(string count utxo);
@@ -47,7 +47,7 @@ saveTransactionInputs:{[Block]
   inputs:inputs lj update spent:1b from utxo;
   inputs:update address:@[address;where 0h=type each address;raze/] from inputs;
   inputs:coinbase,:delete txuid from inputs;
-  insert[`addressLookup;select address,height,partition:heightToPartition[index;chunkSize],tag:`$-3#'address,bitmex:{?[x like "3BMEX";1b;0b]}each 5#'address from inputs where not address like ""];
+  insert[`addressLookup;select address,height,partition:heightToPartition[index;chunkSize],tag:`$-3#'address,bitmex:?[(inputs`address) like "3BMEX";1b;0b] from inputs where not address like ""];
   insert[`txInputs;inputs];
  }
 


### PR DESCRIPTION
Is this more efficient than using a lambda function? I've tried this with dummy data:

address height partition tag BitMEX
-----------------------------------
C       1      1         C11 1     
B       23     1         C11 0     
B       23     1         C11 0     
B       23     1         C11 0     
B       3      4         C11 0     

q)\t:10000 update ADDRESS:?[(addressLookup`address)="B";1b;0b] from select address,height from addressLookup
30

q)\t:10000 update ADDRESS:{?[x="B";1b;0b]} each address from select address,height from addressLookup
462